### PR TITLE
Lock activesupport version due to ruby requirements

### DIFF
--- a/puphpet/shell/install-puppet.sh
+++ b/puphpet/shell/install-puppet.sh
@@ -31,4 +31,4 @@ if [[ ! -f /.puphpet-stuff/install-puppet ]]; then
     touch /.puphpet-stuff/install-puppet
 fi
 
-/opt/puppetlabs/puppet/bin/gem install deep_merge activesupport vine --no-ri --no-rdoc
+/opt/puppetlabs/puppet/bin/gem install deep_merge activesupport:'< 5' vine --no-ri --no-rdoc


### PR DESCRIPTION
5.0.x activesupport requires ruby >= 2.2.2, couldn't get box running with current setup.